### PR TITLE
Added multicore and fit options to master_2comp_fit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*test/
+env.yml
+*.pyc
+test.py
+mufasa/master_fit_structure.py

--- a/mufasa/UltraCube.py
+++ b/mufasa/UltraCube.py
@@ -58,11 +58,11 @@ class UltraCube(object):
                 self.cube = cube
 
         if not snr_min is None:
-            self.snr_min = kwargs['snr_min']
+            self.snr_min = snr_min
 
 
         if not rmsfile is None:
-            self.rmsfile = kwargs['rmsfile']
+            self.rmsfile = rmsfile
 
 
     def load_cube(self, fitsfile):

--- a/mufasa/UltraCube.py
+++ b/mufasa/UltraCube.py
@@ -82,7 +82,7 @@ class UltraCube(object):
         if filename is None:
             self.convolve_cube(factor=self.cnv_factor)
         elif os.path.exists(filename):
-            self.cube_cnv = SpectralCube.read(fitsfile)
+            self.cube_cnv = SpectralCube.read(filename)
         else:
             print("[WARNING]: the specified file does not exist.")
 

--- a/mufasa/UltraCube.py
+++ b/mufasa/UltraCube.py
@@ -554,7 +554,7 @@ def get_masked_moment(cube, model, order=0, expand=10, mask=None):
 def expand_mask(mask, expand):
 
     # adds a buffer of size set by the expand keyword to a 2D mask,
-    selem = np.ones(expand,dtype=np.bool)
+    selem = np.ones(expand,dtype=bool)
     selem.shape += (1,1,)
     mask = nd.binary_dilation(mask, selem)
     return mask

--- a/mufasa/UltraCube.py
+++ b/mufasa/UltraCube.py
@@ -65,7 +65,6 @@ class UltraCube(object):
             self.rmsfile = kwargs['rmsfile']
 
 
-
     def load_cube(self, fitsfile):
         # loads SpectralCube
         self.cube = SpectralCube.read(fitsfile)
@@ -89,7 +88,11 @@ class UltraCube(object):
 
 
     def fit_cube(self, ncomp, simpfit=False, **kwargs):
-        # currently limited to NH3 (1,1) 2-slab fit
+        '''
+        currently limited to NH3 (1,1) 2-slab fit
+
+        kwargs are those used for pyspeckit.Cube.fiteach
+        '''
 
         if not 'multicore' in kwargs:
             kwargs['multicore'] = self.n_cores #multiprocessing.cpu_count()
@@ -119,6 +122,7 @@ class UltraCube(object):
             self.master_model_mask = mask
         else:
             self.master_model_mask = np.logical_or(self.master_model_mask, mask)
+
 
     def save_fit(self, savename, ncomp):
         # note, this implementation currently relies on
@@ -152,6 +156,7 @@ class UltraCube(object):
 
         self.rms_maps[compID] = get_rms(self.residual_cubes[compID])
         return self.rms_maps[compID]
+
 
     def get_rss(self, ncomp, mask=None):
         # residual sum of squares
@@ -237,9 +242,12 @@ class UCubePlus(UltraCube):
         self.paraPaths = {}
 
 
-
     def get_model_fit(self, ncomp, update=True, **kwargs):
-        # load the model fits if it exist, else
+        '''
+        load the model fits if it exist, else
+
+        kwargs are passed to pyspeckit.Cube.fiteach (if update)
+        '''
 
         for nc in ncomp:
             if not str(nc) in self.paraPaths:
@@ -264,6 +272,9 @@ class UCubePlus(UltraCube):
 #======================================================================================================================#
 
 def fit_cube(cube, simpfit=False, **kwargs):
+    '''
+    kwargs are those used for pyspeckit.Cube.fiteach
+    '''
     if simpfit:
         # fit the cube with the provided guesses and masks with no pre-processing
         return mvf.cubefit_simp(cube, **kwargs)
@@ -421,7 +432,6 @@ def get_rss(cube, model, expand=20, usemask = True, mask = None, return_size=Tru
     return returns
 
 
-
 def get_chisq(cube, model, expand=20, reduced = True, usemask = True, mask = None):
     '''
     cube : SpectralCube
@@ -474,7 +484,6 @@ def get_chisq(cube, model, expand=20, reduced = True, usemask = True, mask = Non
     else:
         # return the ch-squared values and the number of data points used
         return chisq, np.nansum(mask, axis=0)
-
 
 
 def get_masked_moment(cube, model, order=0, expand=10, mask=None):

--- a/mufasa/UltraCube.py
+++ b/mufasa/UltraCube.py
@@ -418,7 +418,7 @@ def get_rss(cube, model, expand=20, usemask = True, mask = None, return_size=Tru
     # plus a buffer of size set by the expand keyword.
     if expand > 0:
         mask = expand_mask(mask, expand)
-    mask = mask.astype(np.float)
+    mask = mask.astype(float)
 
     # note: using nan-sum may walk over some potential bad pixel cases
     rss = np.nansum((residual * mask)**2, axis=0)
@@ -464,7 +464,7 @@ def get_chisq(cube, model, expand=20, reduced = True, usemask = True, mask = Non
     # plus a buffer of size set by the expand keyword.
     if expand > 0:
         mask = expand_mask(mask, expand)
-    mask = mask.astype(np.float)
+    mask = mask.astype(float)
 
     # note: using nan-sum may walk over some potential bad pixel cases
     chisq = np.nansum((residual * mask) ** 2, axis=0)
@@ -528,7 +528,7 @@ def get_masked_moment(cube, model, order=0, expand=10, mask=None):
     # plus a buffer of size set by the expand keyword.
     if expand > 0:
         mask = expand_mask(mask, expand)
-    mask = mask.astype(np.float)
+    mask = mask.astype(float)
 
 
     '''

--- a/mufasa/UltraCube.py
+++ b/mufasa/UltraCube.py
@@ -21,7 +21,7 @@ from . import convolve_tools as cnvtool
 
 class UltraCube(object):
 
-    def __init__(self, cubefile=None, cube=None, snr_min=None, rmsfile=None, cnv_factor=2):
+    def __init__(self, cubefile=None, cube=None, snr_min=None, rmsfile=None, cnv_factor=2, multicore=None):
         '''
         # a data frame work to handel multiple component fits and their results
         Parameters
@@ -43,7 +43,10 @@ class UltraCube(object):
         self.master_model_mask = None
         self.snr_min = 0.0
         self.cnv_factor = cnv_factor
-        self.n_cores = multiprocessing.cpu_count()
+        if multicore is None:
+            self.n_cores = multiprocessing.cpu_count() - 1
+        else:
+            self.n_cores = multicore
 
         if cubefile is not None:
             self.cubefile = cubefile
@@ -89,7 +92,7 @@ class UltraCube(object):
         # currently limited to NH3 (1,1) 2-slab fit
 
         if not 'multicore' in kwargs:
-            kwargs['multicore'] = multiprocessing.cpu_count()
+            kwargs['multicore'] = self.n_cores #multiprocessing.cpu_count()
 
         if not 'snr_min' in kwargs:
             kwargs['snr_min'] = self.snr_min

--- a/mufasa/master_fitter.py
+++ b/mufasa/master_fitter.py
@@ -230,7 +230,11 @@ def refit_swap_2comp(reg, snr_min=3, **kwargs):
 
 
 
-def refit_2comp_wide(reg, snr_min=3, method='residual', planemask=None, **kwargs):
+def refit_2comp_wide(reg, snr_min=3, planemask=None, **kwargs):
+    if 'wide_refit_method' in kwargs:
+       method =  kwargs['wide_refit_method']
+    else:
+        method = 'residual'
 
     print("begin wide component recovery")
 

--- a/mufasa/multi_v_fit.py
+++ b/mufasa/multi_v_fit.py
@@ -115,7 +115,6 @@ def get_multiV_models(paraname, refcubename, n_comp = 2, savename = None, snrnam
     return cubes
 
 
-
 def get_SNR(paraname, savename = None, rms = 0.15, n_comp = 2, linename='oneone'):
     '''
     Take a multiple velocity componet fit and produce a signal to noise ratio of the two velocity components
@@ -239,7 +238,6 @@ def get_chisq(cube, model, expand=20, reduced = True, usemask = True, mask = Non
         return chisq, np.sum(mask, axis=0)
 
 
-
 def main_hf_moments(maskcube, window_hwidth, v_atpeak=None, signal_mask=None):
     '''
     # find moments for the main hyperfine lines
@@ -275,7 +273,6 @@ def moment_guesses(moment1, moment2, ncomp, sigmin=0.07, tex_guess=3.2, tau_gues
     :return:
     '''
     return momgue.moment_guesses(moment1, moment2, ncomp, sigmin, tex_guess, tau_guess, moment0)
-
 
 
 def make_guesses(sigv_para_name, n_comp = 2, tex_guess =10.0, tau_guess = 0.5):
@@ -525,8 +522,6 @@ def cubefit_simp(cube, ncomp, guesses, multicore = None, maskmap=None, linename=
     '''
 
     return pcube
-
-
 
 
 def cubefit_gen(cube, ncomp=2, paraname = None, modname = None, chisqname = None, guesses = None, errmap11name = None,
@@ -879,7 +874,6 @@ def cubefit_gen(cube, ncomp=2, paraname = None, modname = None, chisqname = None
     return pcube
 
 
-
 def save_pcube(pcube, savename, ncomp=2):
     # a method to save the fitted parameter cube with relavent header information
 
@@ -907,4 +901,3 @@ def save_pcube(pcube, savename, ncomp=2):
 
     fitcubefile = fits.PrimaryHDU(data=np.concatenate([pcube.parcube,pcube.errcube]), header=hdr_new)
     fitcubefile.writeto(savename ,overwrite=True)
-

--- a/mufasa/multi_v_fit.py
+++ b/mufasa/multi_v_fit.py
@@ -848,7 +848,7 @@ def cubefit_gen(cube, ncomp=2, paraname = None, modname = None, chisqname = None
 
     if multicore is None:
         # use n-1 cores on the computer
-        multicore= multiprocessing.cpu_count() - 1
+        multicore = multiprocessing.cpu_count() - 1
 
         if multicore < 1:
             multicore = 1


### PR DESCRIPTION
Allows specifying number of cores to use with `multicore` flag in `master_fitter.Region`. Allows passing additional arguments to all calls of `pyspeckit.fiteach` via `fit_kw` keyword in `master_fitter.Region.master_2comp_fit`.

If multicore is not specified, previous behaviour should apply (uses n-1 cores). If no fit_kw are passed, previous behaviour should apply.

Ex:
`from mufasa import master_fitter as mf`
`reg = mf.Region(cubepath, nameroot, paraDir=outdir, multicore=4)`
`reg.master_2comp_fit(fit_kw=dict(verbose_level=1))`