### PR TITLE
Enable MUFASA to work with N2H+ in addition to NH3

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,27 @@ pip install mufasa
 
 - ```FITS_tools > v0.2```
 
+If you are running a later version of Python, for example, ```Python 3.11```, you likely will have to install the latest versions of ```pyspeckit``` and  ```FITS_tools``` directly from their respective GitHub repository. 
 
 ## Getting Started
 
 ### Minimum Working Example
 
-To perform a two-component NH<sub>3</sub> (1,1) fit automatically, simply run the following: 
+To perform an NH<sub>3</sub> (1,1) fit automatically, up to two components, simply run the following: 
 
 ```
 from mufasa import master_fitter as mf
-uReg = mf.Region(cubePath, paraNameRoot, paraDir, fittype='nh3_multi_v')
-uReg.master_2comp_fit(snr_min=0)
+reg = mf.Region(cubePath, paraNameRoot, paraDir, fittype='nh3_multi_v')
+reg.master_2comp_fit(snr_min=0)
 ```
 
-In the example above, ```cubePath``` is the path to the FITS data cube, ```paraNameRoot``` is the commmon 'root' name to all the outputfiles, and ```paraDir``` is the directory of all the outputfiles. The species being fit is specified by```fittype```. N<sub>2</sub>H+ (1-0) can be fit instead of NH<sub>3</sub> (1,1) by setting ```fittype='n2hp_multi_v'```. If one wishes to fit pixels only above a certain signal-to-noise-ratio (SNR) threshold, use ```snr_min``` to set such a threshold.
+In the example above, ```cubePath``` is the path to the FITS data cube, ```paraNameRoot``` is the common 'root' name to all the output files, ```paraDir``` is the directory of all the outputfiles, and ```fittype``` is the name of the line model to be fitted. 
+
+```MUFASA``` currently offers two spectral line models, specified by the ```fittype``` argument:
+- ```nh3_multi_v```: multi-component NH<sub>3</sub> (1,1) model
+- ```n2hp_multi_v```: multi-component N<sub>2</sub>H<sup>+</sup> (1-0) model
+
+If one wishes to fit pixels only above a specific signal-to-noise-ratio (SNR) threshold, one can specify such a threshold using the ```snr_min``` argument.
 
 
 

--- a/mufasa/UltraCube.py
+++ b/mufasa/UltraCube.py
@@ -29,7 +29,7 @@ logger = get_logger(__name__)
 
 class UltraCube(object):
 
-    def __init__(self, cubefile=None, cube=None,fittype=None, snr_min=None, rmsfile=None, cnv_factor=2):
+    def __init__(self, cubefile=None, cube=None, fittype=None, snr_min=None, rmsfile=None, cnv_factor=2):
         '''
         # a data frame work to handel multiple component fits and their results
         Parameters
@@ -112,7 +112,7 @@ class UltraCube(object):
 
         for nc in ncomp:
             #self.pcubes[str(nc)] = mvf.cubefit_gen(self.cube, ncomp=nc, **kwargs)
-            self.pcubes[str(nc)] = fit_cube(self.cube, simpfit=simpfit, ncomp=nc, fittype=self.fittype, **kwargs)
+            self.pcubes[str(nc)] = fit_cube(self.cube, fittype=self.fittype, simpfit=simpfit, ncomp=nc, **kwargs)
 
             if hasattr(self.pcubes[str(nc)],'parcube'):
                 # update model mask if any fit has been performed
@@ -275,15 +275,15 @@ class UCubePlus(UltraCube):
 
 #======================================================================================================================#
 
-def fit_cube(cube, simpfit=False,fittype='nh3_multi_v',**kwargs):
+def fit_cube(cube, fittype, simpfit=False, **kwargs):
     '''
     kwargs are those used for pyspeckit.Cube.fiteach
     '''
     if simpfit:
         # fit the cube with the provided guesses and masks with no pre-processing
-        return mvf.cubefit_simp(cube,fittype=fittype,**kwargs)
+        return mvf.cubefit_simp(cube, fittype=fittype, **kwargs)
     else:
-        return mvf.cubefit_gen(cube,fittype=fittype,**kwargs)
+        return mvf.cubefit_gen(cube, fittype=fittype, **kwargs)
 
 
 def save_fit(pcube, savename, ncomp):

--- a/mufasa/UltraCube.py
+++ b/mufasa/UltraCube.py
@@ -4,9 +4,14 @@ __author__ = 'mcychen'
 
 #======================================================================================================================#
 import os
+import warnings
 import numpy as np
 
 from spectral_cube import SpectralCube
+# prevent any spectral-cube related warnings from being displayed.
+from spectral_cube.utils import SpectralCubeWarning
+warnings.filterwarnings(action='ignore', category=SpectralCubeWarning, append=True)
+
 import pyspeckit
 import multiprocessing
 import gc
@@ -293,12 +298,12 @@ def load_model_fit(cube, filename, ncomp, fittype):
     # reigster fitter
     if fittype is 'nh3_multi_v':
         linename = 'oneone'
-        from spec_models import ammonia_multiv as ammv
+        from .spec_models import ammonia_multiv as ammv
         fitter = ammv.nh3_multi_v_model_generator(n_comp = ncomp, linenames=[linename])
 
     elif fittype is 'n2hp_multi_v':
         linename = 'onezero'
-        import spec_models.n2hp_multiv as n2hpmv
+        from .spec_models import n2hp_multiv as n2hpmv
         fitter = n2hpmv.n2hp_multi_v_model_generator(n_comp=ncomp, linenames=[linename])
 
     pcube.specfit.Registry.add_fitter(fittype, fitter, fitter.npars)

--- a/mufasa/master_fitter.py
+++ b/mufasa/master_fitter.py
@@ -585,7 +585,7 @@ def fit_best_2comp_residual_cnv(reg, window_hwidth=3.5, res_snr_cut=5, savefit=T
     else:
         maskmap = np.isfinite(mom0)
 
-    reg.ucube_res_cnv = UCube.UltraCube(cube=cube_res_cnv)
+    reg.ucube_res_cnv = UCube.UltraCube(cube=cube_res_cnv, fittype=reg.fittype)
 
     if np.sum(maskmap) > 0:
         mom0[~maskmap] = np.nan

--- a/mufasa/master_fitter.py
+++ b/mufasa/master_fitter.py
@@ -504,7 +504,11 @@ def get_2comp_wide_guesses(reg):
             fit_best_2comp_residual_cnv(reg)
         except ValueError:
             logger.info("retry with no SNR threshold")
-            fit_best_2comp_residual_cnv(reg, window_hwidth=4.0, res_snr_cut=0.0)
+            try:
+                fit_best_2comp_residual_cnv(reg, window_hwidth=4.0, res_snr_cut=0.0)
+            except ValueError as e:
+                logger.info(e)
+                pass
 
 
     def get_mom_guesses(reg):
@@ -576,8 +580,8 @@ def fit_best_2comp_residual_cnv(reg, window_hwidth=3.5, res_snr_cut=5, savefit=T
 
     try:
         moms_res_cnv = mmg.window_moments(pcube_res_cnv, v_atpeak=vmap, window_hwidth=window_hwidth)
-    except ValueError:
-        raise Exception("There doesn't seem to be enough pixels to find the residual moments")
+    except ValueError as e:
+        raise ValueError("There doesn't seem to be enough pixels to find the residual moments. {}".format(e))
 
     gg = mmg.moment_guesses_1c(moms_res_cnv[0], moms_res_cnv[1], moms_res_cnv[2])
 

--- a/mufasa/master_fitter.py
+++ b/mufasa/master_fitter.py
@@ -503,7 +503,7 @@ def get_2comp_wide_guesses(reg):
             fit_best_2comp_residual_cnv(reg)
         except ValueError:
             logger.info("retry with no SNR threshold")
-            fit_best_2comp_residual_cnv(reg, window_hwidth=4.0, res_snr_cut=0.0,fittype=reg.fittype)
+            fit_best_2comp_residual_cnv(reg, window_hwidth=4.0, res_snr_cut=0.0)
 
 
     def get_mom_guesses(reg):

--- a/mufasa/master_fitter.py
+++ b/mufasa/master_fitter.py
@@ -13,6 +13,7 @@ import gc
 from scipy.signal import medfilt2d
 from skimage.morphology import dilation, square
 from time import ctime
+import warnings
 
 from . import UltraCube as UCube
 from . import moment_guess as mmg
@@ -26,7 +27,7 @@ logger = get_logger(__name__)
 
 class Region(object):
 
-    def __init__(self, cubePath, paraNameRoot, paraDir=None, cnv_factor=2, fittype='nh3_multi_v',**kwargs):
+    def __init__(self, cubePath, paraNameRoot, paraDir=None, cnv_factor=2, fittype=None, **kwargs):
         """initialize region object
             :param cubePath (str): path to spectral cube
             :param paraNameRoot (str): string to prepend to output file names
@@ -44,8 +45,14 @@ class Region(object):
         self.cubePath = cubePath
         self.paraNameRoot = paraNameRoot
         self.paraDir = paraDir
+        if fittype is None:
+            fittype = 'nh3_multi_v'
+            message = "[WARNING] The optionality of the fittype argment for the Region class will be deprecated in the future. " \
+                      "Please ensure the fittype argument is specified going forward."
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+
         self.fittype = fittype
-        self.ucube = UCube.UCubePlus(cubePath, paraNameRoot=paraNameRoot, paraDir=paraDir, cnv_factor=cnv_factor,fittype=self.fittype)
+        self.ucube = UCube.UCubePlus(cubePath, paraNameRoot=paraNameRoot, paraDir=paraDir, cnv_factor=cnv_factor, fittype=self.fittype)
 
         # for convolving cube
         self.cnv_factor = cnv_factor


### PR DESCRIPTION
MUFASA can now run N2H+ fitting automatically up to two components. The software is also restructured to accommodate the integration of other line models for future developments.